### PR TITLE
Update examples to PHP >= 5.4 Strict standarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,15 @@ php artisan vendor:publish
 That's all what we need.
 
 ## Usage
-Create a model transformer class by extending the AbstractTransformer class:
+Create a model transformer class by extending the AbstractTransformer class(and don't forget to set namespace):
 
 ```php
 <?php
+use Illuminate\Database\Eloquent\Model;
+
 class CategoryTransformer extends Themsaid\Transformers\AbstractTransformer
 {
-    public function transformModel(Model $item)
+    protected function transformModel(Model $item)
     {
         $output = [
             'name'		=> $item->name,
@@ -116,9 +118,10 @@ The package contains two helpful methods for dealing with relationships, the fir
 
 ```php
 <?php
+use Illuminate\Database\Eloquent\Model;
 class ProductTransformer extends AbstractTransformer
 {
-    public function transformModel(Model $item)
+    protected function transformModel(Model $item)
     {
         $output = array_only($item->toArray(), ['name', 'id']);
 
@@ -138,9 +141,10 @@ This method helps you know if the model is loaded from a ManyToMany relationship
 
 ```php
 <?php
+use Illuminate\Database\Eloquent\Model;
 class TagTransformer extends AbstractTransformer
 {
-    public function transformModel(Model $item)
+    protected function transformModel(Model $item)
     {
         $output = array_only($item->toArray(), ['name', 'id']);
 
@@ -170,9 +174,10 @@ Now from inside the CategoryTransformer you can check the options parameter:
 
 ```php
 <?php
+use Illuminate\Database\Eloquent\Model;
 class CategoryTransformer extends AbstractTransformer
 {
-    public function transformModel(Model $item)
+    protected function transformModel(Model $item)
     {
     	$output = [];
     


### PR DESCRIPTION
If you are using PHP >= 5.4 you should define which Model used as a parameter, either you will get exception.
