### PR TITLE
Added provider option to vendor:publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Themsaid\Transformers\TransformersServiceProvider::class
 Finally publish the config file:
 
 ```
-php artisan vendor:publish
+php artisan vendor:publish --provider="Themsaid\Transformers\TransformersServiceProvider"
 ```
 
 That's all what we need.


### PR DESCRIPTION
This will avoid people publishing _all_ additional files for packages, where they don't wish to do so.